### PR TITLE
Remove-listener method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,10 @@ const cliSize = require("cli-size");
  * @name CliResize
  * @function
  * @param {Function} fn The callback function which is called when the terminal is resized.
+ * @returns {Function} A function that disables the resize listener.
  */
 module.exports = fn => {
-    process.on("SIGWINCH", () => fn(cliSize()))
+    const listener = () => fn(cliSize());
+    process.on("SIGWINCH", listener);
+    return () => process.removeListener("SIGWINCH", listener);
 };


### PR DESCRIPTION
Great library! Saw that there was no way to stop the listener once attached, so I added such a feature.